### PR TITLE
fixed reference year in getMonthPollutionEstimate.R

### DIFF
--- a/pkg/R/getMonthPollutionEstimate.R
+++ b/pkg/R/getMonthPollutionEstimate.R
@@ -21,7 +21,7 @@ getMonthPollutionEstimate <- function(long, lat, pollutant = "PM2.5", monthyear)
                               "CO" = download(pr_co_monthly_brick))
 
     month_year <- as.numeric(strsplit(monthyear, "-")[[1]])
-    ind <- 12*(month_year[2]-1996) + month_year[1]
+    ind <- 12*(month_year[2]-1997) + month_year[1]
 
     raster::extract(pollutant_brick[[ind]], cbind(long,lat))
   } else {
@@ -34,7 +34,7 @@ getMonthPollutionEstimate <- function(long, lat, pollutant = "PM2.5", monthyear)
                               "CO" = download(co_monthly_brick))
 
     month_year <- as.numeric(strsplit(monthyear, "-")[[1]])
-    ind <- 12*(month_year[2]-1996) + month_year[1]
+    ind <- 12*(month_year[2]-1997) + month_year[1]
 
     raster::extract(pollutant_brick[[ind]], cbind(long,lat))
   }


### PR DESCRIPTION
Reference year in file pargasite/pkg/R/getMonthPollutionEstimate.R was 1996, leading to error when retrieving 2021 monthly values. Changed reference year to 1997.